### PR TITLE
fix: clean up read exercise interface

### DIFF
--- a/packages/web/src/components/staff-primitives.tsx
+++ b/packages/web/src/components/staff-primitives.tsx
@@ -29,7 +29,11 @@ export function StaffLines({
       ))}
       <text
         x={20}
-        y={STAFF_TOP + 3.3 * LINE_SPACING}
+        y={
+          clef === "treble"
+            ? STAFF_TOP + 3.3 * LINE_SPACING
+            : STAFF_TOP + 2.8 * LINE_SPACING
+        }
         fontSize={72}
         fontFamily="serif"
         fill={COLORS.foreground}

--- a/packages/web/src/routes/read.$level.tsx
+++ b/packages/web/src/routes/read.$level.tsx
@@ -149,20 +149,6 @@ function ReadExercise() {
         feedback={feedback}
       />
 
-      {feedback &&
-        match(feedback)
-          .with("correct", () => (
-            <div className="text-center text-xl font-bold py-2 border-3 border-border bg-accent">
-              {t("read.correct")}
-            </div>
-          ))
-          .with("wrong", () => (
-            <div className="text-center text-xl font-bold py-2 border-3 border-border bg-destructive text-destructive-foreground">
-              {t("read.wrong")}
-            </div>
-          ))
-          .exhaustive()}
-
       <AnswerButtons
         disabled={exerciseState === "finished"}
         allowedNotes={exercise.allowedNotes}


### PR DESCRIPTION
Removes correct/wrong popup messages that broke the layout and fixes bass clef positioning for better visual alignment.

- Remove correct/wrong popup messages that break layout
- Fix bass clef positioning for better visual alignment
- Green highlighting for correct notes already working properly

Closes #5

Generated with [Claude Code](https://claude.ai/code)