### PR TITLE
feat: improve exercise sets with tier-based length and new note bias

### DIFF
--- a/packages/api/src/routes/notation.ts
+++ b/packages/api/src/routes/notation.ts
@@ -3,6 +3,7 @@ import {
   CLEF_RANGES,
   defaultClefSchema,
   getExerciseLevel,
+  getNewNotes,
   type NotationExercise,
   type NotationQuery,
   notationQuerySchema,
@@ -66,6 +67,69 @@ function getCandidatePool(
   return pool;
 }
 
+function generateNotesWithNewNoteBias(
+  candidates: string[],
+  count: number,
+  newNotes: string[],
+  clef: "treble" | "bass",
+): string[] {
+  if (newNotes.length === 0) {
+    // No new notes, use pure random selection
+    return Array.from(
+      { length: count },
+      () => candidates[Math.floor(Math.random() * candidates.length)] as string,
+    );
+  }
+
+  // Get variants for new notes within the clef range
+  const range = CLEF_RANGES[clef];
+  const lowMidi = Note.midi(range.low) as number;
+  const highMidi = Note.midi(range.high) as number;
+
+  const newNoteCandidates: string[] = [];
+  for (const noteName of newNotes) {
+    for (let octave = 2; octave <= 6; octave++) {
+      const full = `${noteName}${octave}`;
+      const midi = Note.midi(full);
+      if (midi !== null && midi >= lowMidi && midi <= highMidi) {
+        if (candidates.includes(full)) {
+          newNoteCandidates.push(full);
+        }
+      }
+    }
+  }
+
+  const notes: string[] = [];
+
+  // Ensure at least 50% of notes are from new notes if available
+  const newNoteTargetCount = Math.min(
+    Math.ceil(count * 0.5),
+    newNoteCandidates.length > 0 ? count : 0,
+  );
+
+  // Add new notes first
+  for (let i = 0; i < newNoteTargetCount && newNoteCandidates.length > 0; i++) {
+    const randomIndex = Math.floor(Math.random() * newNoteCandidates.length);
+    notes.push(newNoteCandidates[randomIndex] as string);
+  }
+
+  // Fill remaining with random selection from all candidates
+  const remainingCount = count - notes.length;
+  for (let i = 0; i < remainingCount; i++) {
+    notes.push(
+      candidates[Math.floor(Math.random() * candidates.length)] as string,
+    );
+  }
+
+  // Shuffle the notes so new notes aren't always at the beginning
+  for (let i = notes.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [notes[i], notes[j]] = [notes[j] as string, notes[i] as string];
+  }
+
+  return notes;
+}
+
 export async function notationRoutes(app: FastifyInstance) {
   app.get<{
     Querystring: NotationQuery;
@@ -89,9 +153,12 @@ export async function notationRoutes(app: FastifyInstance) {
       params.degrees,
     );
 
-    const notes = Array.from(
-      { length: params.count },
-      () => candidates[Math.floor(Math.random() * candidates.length)] as string,
+    const newNotes = getNewNotes(levelNum);
+    const notes = generateNotesWithNewNoteBias(
+      candidates,
+      params.count,
+      newNotes,
+      clef,
     );
 
     return {

--- a/packages/shared/src/levels.test.ts
+++ b/packages/shared/src/levels.test.ts
@@ -37,10 +37,17 @@ describe("EXERCISE_LEVELS", () => {
     expect(level4.tempo).toBe(52);
   });
 
-  it("sets count to 10 for every level", () => {
-    for (const level of EXERCISE_LEVELS) {
-      expect(level.count).toBe(10);
-    }
+  it("sets count based on tier (10, 13, 16, 20) with 25 for last level", () => {
+    // Check first 4 levels (first scale group)
+    expect(EXERCISE_LEVELS[0].count).toBe(10); // Introduction
+    expect(EXERCISE_LEVELS[1].count).toBe(13); // Practice
+    expect(EXERCISE_LEVELS[2].count).toBe(16); // Consolidation
+    expect(EXERCISE_LEVELS[3].count).toBe(20); // Mastery
+    
+    // Check last level (level 40)
+    const lastLevel = EXERCISE_LEVELS[EXERCISE_LEVELS.length - 1];
+    expect(lastLevel.count).toBe(25);
+    expect(lastLevel.level).toBe(40);
   });
 });
 

--- a/packages/shared/src/levels.ts
+++ b/packages/shared/src/levels.ts
@@ -79,18 +79,29 @@ export const STEP_LABELS = [
   "Mastery",
 ] as const;
 
-const NOTE_COUNT = 10;
+function getNotesCountForStep(stepIndex: number, isLastLevel: boolean): number {
+  if (isLastLevel) return 25;
+
+  // stepIndex: 0=Introduction, 1=Practice, 2=Consolidation, 3=Mastery
+  const counts = [10, 13, 16, 20];
+  return counts[stepIndex] ?? 10;
+}
 
 export const EXERCISE_LEVELS: ExerciseLevel[] = SCALE_GROUPS.flatMap(
   (group, groupIndex) =>
-    STEP_LABELS.map((step, stepIndex) => ({
-      level: groupIndex * 4 + stepIndex + 1,
-      name: `${group.name} — ${step}`,
-      scale: group.scale,
-      count: NOTE_COUNT,
-      tempo: group.tempos[stepIndex],
-      degrees: group.degrees[stepIndex],
-    })),
+    STEP_LABELS.map((step, stepIndex) => {
+      const level = groupIndex * 4 + stepIndex + 1;
+      const isLastLevel = level === SCALE_GROUPS.length * 4;
+
+      return {
+        level,
+        name: `${group.name} — ${step}`,
+        scale: group.scale,
+        count: getNotesCountForStep(stepIndex, isLastLevel),
+        tempo: group.tempos[stepIndex],
+        degrees: group.degrees[stepIndex],
+      };
+    }),
 );
 
 const LEVEL_MAP = new Map(EXERCISE_LEVELS.map((l) => [l.level, l]));


### PR DESCRIPTION
Implements improvements to exercise sets as requested in issue #7:

- **Tier-based exercise lengths**: 10/13/16/20 notes based on difficulty, 25 for last level
- **Enhanced note selection**: Prioritizes new notes with 50% minimum inclusion rate
- **Improved randomness**: Addresses issue where new notes weren't appearing frequently enough

Closes #7

🤖 Generated with [Claude Code](https://claude.ai/code)