### PR TITLE
feat: add MIDI integration for piano exercises

### DIFF
--- a/packages/web/src/components/midi-indicator.tsx
+++ b/packages/web/src/components/midi-indicator.tsx
@@ -1,0 +1,110 @@
+import { useTranslation } from "react-i18next";
+import {
+  type MidiConnectionState,
+  useMidiConnection,
+} from "@/hooks/use-midi-connection";
+import { Button } from "./button";
+
+interface MidiIndicatorProps {
+  onNotePress?: (noteLetter: string) => void;
+  enableNoteInput?: boolean;
+}
+
+export function MidiIndicator({
+  onNotePress,
+  enableNoteInput,
+}: MidiIndicatorProps) {
+  const { t } = useTranslation();
+  const {
+    state,
+    availableDevices,
+    connectedDevice,
+    error,
+    userDeniedConnection,
+    requestAccess,
+    connectToDevice,
+    disconnect,
+  } = useMidiConnection({ onNotePress, enableNoteInput });
+
+  const getStatusColor = (state: MidiConnectionState): string => {
+    switch (state) {
+      case "connected":
+        return "bg-green-500";
+      case "connecting":
+        return "bg-yellow-500";
+      case "disconnected":
+        return "bg-gray-400";
+    }
+  };
+
+  const getStatusText = (state: MidiConnectionState): string => {
+    switch (state) {
+      case "connected":
+        return t("midi.connected");
+      case "connecting":
+        return t("midi.connecting");
+      case "disconnected":
+        return t("midi.disconnected");
+    }
+  };
+
+  const handleConnect = () => {
+    if (state === "connected" && connectedDevice) {
+      disconnect();
+    } else if (availableDevices.length > 0) {
+      // Connect to first available device
+      const firstDevice = availableDevices[0];
+      if (firstDevice) {
+        connectToDevice(firstDevice.id);
+      }
+    } else {
+      requestAccess();
+    }
+  };
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50">
+      <div className="flex items-center gap-2 bg-card border-2 border-border rounded-lg p-2 shadow-[var(--shadow-brutal)] text-sm">
+        <div
+          className={`w-2 h-2 rounded-full ${getStatusColor(state)} ${
+            state === "connecting" ? "animate-pulse" : ""
+          }`}
+        />
+        <span className="font-medium">
+          {t("midi.title")}: {getStatusText(state)}
+        </span>
+
+        {connectedDevice && (
+          <span className="text-muted-foreground text-xs max-w-24 truncate">
+            {connectedDevice.name}
+          </span>
+        )}
+
+        <Button
+          size="sm"
+          variant={state === "connected" ? "default" : "primary"}
+          onClick={handleConnect}
+          className="ml-2 text-xs px-2 py-1"
+        >
+          {state === "connected"
+            ? t("midi.disconnect")
+            : availableDevices.length > 0
+              ? t("midi.connect")
+              : t("midi.enable")}
+        </Button>
+      </div>
+
+      {error && !userDeniedConnection && (
+        <div className="mt-2 bg-red-100 border-2 border-red-300 text-red-800 p-2 rounded text-xs max-w-64">
+          {error}
+        </div>
+      )}
+
+      {userDeniedConnection && (
+        <div className="mt-2 bg-yellow-100 border-2 border-yellow-300 text-yellow-800 p-2 rounded text-xs max-w-64">
+          {t("midi.permissionDenied")}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/hooks/use-midi-connection.ts
+++ b/packages/web/src/hooks/use-midi-connection.ts
@@ -1,0 +1,240 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type MidiConnectionState = "disconnected" | "connecting" | "connected";
+
+export interface MidiDevice {
+  id: string;
+  name: string;
+  manufacturer?: string;
+}
+
+interface UseMidiConnectionOptions {
+  onNotePress?: (noteLetter: string) => void;
+  enableNoteInput?: boolean;
+}
+
+export function useMidiConnection({
+  onNotePress,
+  enableNoteInput = true,
+}: UseMidiConnectionOptions = {}) {
+  const [state, setState] = useState<MidiConnectionState>("disconnected");
+  const [availableDevices, setAvailableDevices] = useState<MidiDevice[]>([]);
+  const [connectedDevice, setConnectedDevice] = useState<MidiDevice | null>(
+    null,
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [userDeniedConnection, setUserDeniedConnection] = useState(false);
+
+  const midiAccessRef = useRef<MIDIAccess | null>(null);
+  const connectedInputRef = useRef<MIDIInput | null>(null);
+  const onNotePressRef = useRef(onNotePress);
+  onNotePressRef.current = onNotePress;
+
+  // Convert MIDI note number to note letter (C, D, E, F, G, A, B only)
+  const midiNoteToLetter = useCallback((noteNumber: number): string | null => {
+    const noteNames = [
+      "C",
+      "C#",
+      "D",
+      "D#",
+      "E",
+      "F",
+      "F#",
+      "G",
+      "G#",
+      "A",
+      "A#",
+      "B",
+    ];
+    const noteName = noteNames[noteNumber % 12];
+    // Only return natural notes (no sharps/flats) as the app only uses C-G, A, B
+    if (!noteName || noteName.includes("#")) return null;
+    return noteName;
+  }, []);
+
+  // Handle MIDI message
+  const handleMidiMessage = useCallback(
+    (event: MIDIMessageEvent) => {
+      if (!event.data || event.data.length < 2) return;
+
+      const data = Array.from(event.data);
+      const [status, data1] = data;
+
+      // Note on message (status 144-159) with velocity > 0
+      if (status >= 144 && status <= 159 && data1 != null) {
+        const velocity = data[2];
+        if (velocity && velocity > 0) {
+          const noteLetter = midiNoteToLetter(data1);
+          if (noteLetter && enableNoteInput && onNotePressRef.current) {
+            onNotePressRef.current(noteLetter);
+          }
+        }
+      }
+    },
+    [midiNoteToLetter, enableNoteInput],
+  );
+
+  // Get available MIDI devices
+  const refreshDevices = useCallback(async () => {
+    const access = midiAccessRef.current;
+    if (!access) return;
+
+    const devices: MidiDevice[] = [];
+    for (const input of access.inputs.values()) {
+      devices.push({
+        id: input.id,
+        name: input.name || "Unknown Device",
+        manufacturer: input.manufacturer || undefined,
+      });
+    }
+    setAvailableDevices(devices);
+  }, []);
+
+  // Connect to a specific device
+  const connectToDevice = useCallback(
+    async (deviceId: string) => {
+      const access = midiAccessRef.current;
+      if (!access) return;
+
+      const input = access.inputs.get(deviceId);
+      if (!input) {
+        setError("Device not found");
+        return;
+      }
+
+      try {
+        setState("connecting");
+
+        // Disconnect from previous device if any
+        if (connectedInputRef.current) {
+          connectedInputRef.current.removeEventListener(
+            "midimessage",
+            handleMidiMessage,
+          );
+          connectedInputRef.current = null;
+        }
+
+        // Connect to new device
+        input.addEventListener("midimessage", handleMidiMessage);
+        connectedInputRef.current = input;
+
+        setConnectedDevice({
+          id: input.id,
+          name: input.name || "Unknown Device",
+          manufacturer: input.manufacturer || undefined,
+        });
+        setState("connected");
+        setError(null);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to connect");
+        setState("disconnected");
+      }
+    },
+    [handleMidiMessage],
+  );
+
+  // Disconnect from current device
+  const disconnect = useCallback(() => {
+    if (connectedInputRef.current) {
+      connectedInputRef.current.removeEventListener(
+        "midimessage",
+        handleMidiMessage,
+      );
+      connectedInputRef.current = null;
+    }
+    setConnectedDevice(null);
+    setState("disconnected");
+    setError(null);
+  }, [handleMidiMessage]);
+
+  // Request MIDI access
+  const requestAccess = useCallback(async () => {
+    try {
+      setError(null);
+      setUserDeniedConnection(false);
+
+      if (!navigator.requestMIDIAccess) {
+        setError("MIDI not supported in this browser");
+        return;
+      }
+
+      setState("connecting");
+      const access = await navigator.requestMIDIAccess();
+
+      midiAccessRef.current = access;
+
+      // Set up device change listeners
+      access.addEventListener("statechange", refreshDevices);
+
+      await refreshDevices();
+
+      // Auto-connect to first available device if any
+      const devices = Array.from(access.inputs.values());
+      if (devices.length > 0 && devices[0]) {
+        await connectToDevice(devices[0].id);
+      } else {
+        setState("disconnected");
+      }
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : "Failed to access MIDI";
+      setError(errorMessage);
+      setState("disconnected");
+
+      // Check if user denied permission
+      if (
+        errorMessage.includes("denied") ||
+        errorMessage.includes("NotAllowedError")
+      ) {
+        setUserDeniedConnection(true);
+      }
+    }
+  }, [refreshDevices, connectToDevice]);
+
+  // Initialize MIDI access on mount
+  useEffect(() => {
+    // Check if MIDI is supported
+    if (!navigator.requestMIDIAccess) {
+      setError("MIDI not supported in this browser");
+      return;
+    }
+
+    // Try to get existing access (if previously granted)
+    navigator
+      .requestMIDIAccess()
+      .then((access) => {
+        midiAccessRef.current = access;
+        access.addEventListener("statechange", refreshDevices);
+        refreshDevices();
+
+        // Don't auto-connect on init, let user choose
+        setState("disconnected");
+      })
+      .catch(() => {
+        // User hasn't granted permission yet, that's fine
+        setState("disconnected");
+      });
+
+    return () => {
+      if (midiAccessRef.current) {
+        midiAccessRef.current.removeEventListener(
+          "statechange",
+          refreshDevices,
+        );
+      }
+      disconnect();
+    };
+  }, [refreshDevices, disconnect]);
+
+  return {
+    state,
+    availableDevices,
+    connectedDevice,
+    error,
+    userDeniedConnection,
+    requestAccess,
+    connectToDevice,
+    disconnect,
+    refreshDevices,
+  };
+}

--- a/packages/web/src/localizations/en.ts
+++ b/packages/web/src/localizations/en.ts
@@ -54,7 +54,7 @@ export default {
     wrong: "Wrong!",
     loadingExercise: "Loading exercise...",
     instructions:
-      "Press any note button to begin. Identify each note as it reaches the orange zone. You can also use your keyboard (C, D, E, F, G, A, B).",
+      "Press any note button to begin. Identify each note as it reaches the orange zone. You can also use your keyboard (C, D, E, F, G, A, B) or connect a MIDI piano.",
     notesAndTempo: "{{degrees}} notes · {{tempo}} bpm",
   },
   intro: {
@@ -87,5 +87,16 @@ export default {
     typeDelete: 'Type "DELETE" to confirm:',
     deleteButton: "Delete My Account",
     deleting: "Deleting...",
+  },
+  midi: {
+    title: "MIDI",
+    connected: "Connected",
+    connecting: "Connecting",
+    disconnected: "Disconnected",
+    connect: "Connect",
+    disconnect: "Disconnect",
+    enable: "Enable MIDI",
+    permissionDenied:
+      "MIDI access was denied. Please enable it in your browser settings.",
   },
 } as const;

--- a/packages/web/src/localizations/es.ts
+++ b/packages/web/src/localizations/es.ts
@@ -54,7 +54,7 @@ export default {
     wrong: "¡Incorrecto!",
     loadingExercise: "Cargando ejercicio...",
     instructions:
-      "Pulsa cualquier botón de nota para empezar. Identifica cada nota cuando llegue a la zona naranja. También puedes usar tu teclado (C, D, E, F, G, A, B).",
+      "Pulsa cualquier botón de nota para empezar. Identifica cada nota cuando llegue a la zona naranja. También puedes usar tu teclado (C, D, E, F, G, A, B) o conectar un piano MIDI.",
     notesAndTempo: "{{degrees}} notas · {{tempo}} bpm",
   },
   intro: {
@@ -87,5 +87,16 @@ export default {
     typeDelete: 'Escribe "DELETE" para confirmar:',
     deleteButton: "Eliminar mi cuenta",
     deleting: "Eliminando...",
+  },
+  midi: {
+    title: "MIDI",
+    connected: "Conectado",
+    connecting: "Conectando",
+    disconnected: "Desconectado",
+    connect: "Conectar",
+    disconnect: "Desconectar",
+    enable: "Habilitar MIDI",
+    permissionDenied:
+      "Se denegó el acceso MIDI. Por favor, habilítalo en la configuración de tu navegador.",
   },
 } as const;

--- a/packages/web/src/localizations/fr.ts
+++ b/packages/web/src/localizations/fr.ts
@@ -55,7 +55,7 @@ export default {
     wrong: "Faux !",
     loadingExercise: "Chargement de l'exercice...",
     instructions:
-      "Appuyez sur un bouton de note pour commencer. Identifiez chaque note lorsqu'elle atteint la zone orange. Vous pouvez aussi utiliser votre clavier (C, D, E, F, G, A, B).",
+      "Appuyez sur un bouton de note pour commencer. Identifiez chaque note lorsqu'elle atteint la zone orange. Vous pouvez aussi utiliser votre clavier (C, D, E, F, G, A, B) ou connecter un piano MIDI.",
     notesAndTempo: "{{degrees}} notes · {{tempo}} bpm",
   },
   intro: {
@@ -88,5 +88,16 @@ export default {
     typeDelete: 'Tapez "DELETE" pour confirmer :',
     deleteButton: "Supprimer mon compte",
     deleting: "Suppression...",
+  },
+  midi: {
+    title: "MIDI",
+    connected: "Connecté",
+    connecting: "Connexion",
+    disconnected: "Déconnecté",
+    connect: "Connecter",
+    disconnect: "Déconnecter",
+    enable: "Activer MIDI",
+    permissionDenied:
+      "L'accès MIDI a été refusé. Veuillez l'activer dans les paramètres de votre navigateur.",
   },
 } as const;

--- a/packages/web/src/localizations/zh.ts
+++ b/packages/web/src/localizations/zh.ts
@@ -52,7 +52,7 @@ export default {
     wrong: "错误！",
     loadingExercise: "加载练习中...",
     instructions:
-      "按任意音符按钮开始。当音符到达橙色区域时识别它。你也可以使用键盘（C、D、E、F、G、A、B）。",
+      "按任意音符按钮开始。当音符到达橙色区域时识别它。你也可以使用键盘（C、D、E、F、G、A、B）或连接 MIDI 钢琴。",
     notesAndTempo: "{{degrees}} 个音符 · {{tempo}} bpm",
   },
   intro: {
@@ -85,5 +85,15 @@ export default {
     typeDelete: '输入 "DELETE" 以确认：',
     deleteButton: "删除我的账户",
     deleting: "删除中...",
+  },
+  midi: {
+    title: "MIDI",
+    connected: "已连接",
+    connecting: "连接中",
+    disconnected: "未连接",
+    connect: "连接",
+    disconnect: "断开连接",
+    enable: "启用 MIDI",
+    permissionDenied: "MIDI 访问被拒绝。请在浏览器设置中启用它。",
   },
 } as const;

--- a/packages/web/src/routes/read.$level.tsx
+++ b/packages/web/src/routes/read.$level.tsx
@@ -8,6 +8,7 @@ import { AnswerButtons } from "@/components/answer-buttons";
 import { Button } from "@/components/button";
 import { ExerciseIntroModal } from "@/components/exercise-intro-modal";
 import { ExerciseResults } from "@/components/exercise-results";
+import { MidiIndicator } from "@/components/midi-indicator";
 import { StaffRenderer } from "@/components/staff-renderer";
 import { useNotationExercise } from "@/hooks/use-notation-exercise";
 
@@ -166,6 +167,11 @@ function ReadExercise() {
         ))
         .with("playing", () => null)
         .exhaustive()}
+
+      <MidiIndicator
+        onNotePress={handleAnswer}
+        enableNoteInput={exerciseState !== "finished"}
+      />
     </div>
   );
 }

--- a/packages/web/src/types/web-midi.d.ts
+++ b/packages/web/src/types/web-midi.d.ts
@@ -1,0 +1,59 @@
+// Web MIDI API type definitions
+// Based on W3C specification: https://webaudio.github.io/web-midi-api/
+
+interface MIDIAccess extends EventTarget {
+  readonly inputs: MIDIInputMap;
+  readonly outputs: MIDIOutputMap;
+  readonly sysexEnabled: boolean;
+  onstatechange?: ((event: MIDIConnectionEvent) => void) | null;
+}
+
+interface MIDIInputMap extends ReadonlyMap<string, MIDIInput> {}
+
+interface MIDIOutputMap extends ReadonlyMap<string, MIDIOutput> {}
+
+interface MIDIPort extends EventTarget {
+  readonly id: string;
+  readonly manufacturer?: string;
+  readonly name?: string;
+  readonly type: MIDIPortType;
+  readonly version?: string;
+  readonly state: MIDIPortDeviceState;
+  readonly connection: MIDIPortConnectionState;
+  onstatechange?: ((event: MIDIConnectionEvent) => void) | null;
+  open(): Promise<MIDIPort>;
+  close(): Promise<MIDIPort>;
+}
+
+interface MIDIInput extends MIDIPort {
+  readonly type: "input";
+  onmidimessage?: ((event: MIDIMessageEvent) => void) | null;
+}
+
+interface MIDIOutput extends MIDIPort {
+  readonly type: "output";
+  send(data: Uint8Array | number[], timestamp?: number): void;
+  clear(): void;
+}
+
+interface MIDIMessageEvent extends Event {
+  readonly data: Uint8Array;
+  readonly timeStamp: number;
+}
+
+interface MIDIConnectionEvent extends Event {
+  readonly port: MIDIPort;
+}
+
+type MIDIPortType = "input" | "output";
+type MIDIPortDeviceState = "disconnected" | "connected";
+type MIDIPortConnectionState = "open" | "closed" | "pending";
+
+interface Navigator {
+  requestMIDIAccess(options?: MIDIOptions): Promise<MIDIAccess>;
+}
+
+interface MIDIOptions {
+  sysex?: boolean;
+  software?: boolean;
+}


### PR DESCRIPTION
Implements MIDI integration for the piano learning app as requested in ##8.

## 🎹 Features

- **MIDI Device Detection**: Auto-detects MIDI input devices using Web MIDI API
- **User Connection Prompt**: Asks user permission to connect when devices are found
- **Connection Indicator**: Bottom-right status indicator showing MIDI connection state
- **Exercise Integration**: MIDI input works alongside keyboard input during exercises
- **Internationalization**: Full i18n support in English, French, Spanish, and Chinese

## 🔧 Technical Implementation

- `useMidiConnection` hook for MIDI device management
- `MidiIndicator` component for UI controls and status
- Type-safe Web MIDI API integration with proper error handling
- Note filtering to only accept natural notes (C, D, E, F, G, A, B)
- Graceful fallback when MIDI is not supported or available

## ✅ Testing

- All existing tests pass (80/80)
- Lint and TypeScript checks pass
- Follows project coding conventions

Closes ##8

🤖 Generated with [Claude Code](https://claude.ai/code)