### PR TITLE
fix: prevent new chords from joining previous group

### DIFF
--- a/packages/web/src/stores/grid-editor.test.ts
+++ b/packages/web/src/stores/grid-editor.test.ts
@@ -208,13 +208,16 @@ describe("clearChord", () => {
 });
 
 describe("addSquare", () => {
-  it("adds an empty square to the last group", () => {
+  it("adds an empty square as a new group", () => {
     store().initialize(makeGrid());
     store().addSquare();
 
     expect(store().data.squares).toHaveLength(5);
     expect(store().data.squares[4]?.chord).toBeNull();
-    expect(store().data.groups[0]?.squareCount).toBe(5);
+    expect(store().data.groups).toHaveLength(2);
+    expect(store().data.groups[0]?.squareCount).toBe(4);
+    expect(store().data.groups[1]?.squareCount).toBe(1);
+    expect(store().data.groups[1]?.repeatCount).toBe(1);
     expect(store().isDirty).toBe(true);
   });
 });

--- a/packages/web/src/stores/grid-editor.ts
+++ b/packages/web/src/stores/grid-editor.ts
@@ -154,17 +154,10 @@ export const useGridEditorStore = create<GridEditorStore>((set, get) => ({
 
   addSquare: () =>
     set((state) => {
-      const lastGroup = state.data.groups[state.data.groups.length - 1];
-      if (!lastGroup) return state;
-      const newGroups = [...state.data.groups];
-      newGroups[newGroups.length - 1] = {
-        ...lastGroup,
-        squareCount: lastGroup.squareCount + 1,
-      };
       return {
         data: {
           squares: [...state.data.squares, EMPTY_SQUARE],
-          groups: newGroups,
+          groups: [...state.data.groups, { squareCount: 1, repeatCount: 1 }],
         },
         isDirty: true,
       };


### PR DESCRIPTION
Fixes issue where adding a chord in the grid editor would automatically add it to the previous group.

Now each new chord creates its own group, allowing independent management until explicitly grouped.

Closes #17

Generated with [Claude Code](https://claude.ai/code)