### PR TITLE
fix: stop drum playback when component unmounts

### DIFF
--- a/packages/web/src/hooks/use-grid-playback.ts
+++ b/packages/web/src/hooks/use-grid-playback.ts
@@ -270,10 +270,9 @@ export function useGridPlayback(
 
   useEffect(() => {
     return () => {
-      isPlayingRef.current = false;
-      clearScheduled();
+      stop();
     };
-  }, [clearScheduled]);
+  }, [stop]);
 
   return {
     isPlaying,


### PR DESCRIPTION
Fixed issue where drum patterns continued playing when navigating between pages. The useGridPlayback cleanup effect now properly calls stop() which includes stopDrums(), stopBass(), and stopAll().

Closes #28

🤖 Generated with [Claude Code](https://claude.ai/code)