### PR TITLE
fix(web): clamp swing values to prevent cancellation above 50%

### DIFF
--- a/packages/web/src/lib/drum-engine.ts
+++ b/packages/web/src/lib/drum-engine.ts
@@ -14,7 +14,7 @@ export function startDrums(
   const kit = getDrumKit();
   const transport = Tone.getTransport();
   transport.bpm.value = tempo;
-  transport.swing = swing;
+  transport.swing = Math.min(swing, 0.5);
   transport.swingSubdivision = "8n";
 
   sequence = new Tone.Sequence(


### PR DESCRIPTION
Fixes issue where swing slider would cancel itself when values exceed 50%.
Tone.js transport.swing has problems with values > 0.5, so we now clamp
the swing value to maximum 0.5 when passed to the transport.

Closes #29

Generated with [Claude Code](https://claude.ai/code)