### PR TITLE
feat: add transpose feature for chord grids

### DIFF
--- a/packages/web/src/components/accomp/grid-square.tsx
+++ b/packages/web/src/components/accomp/grid-square.tsx
@@ -7,6 +7,8 @@ import {
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
+import { transposeChord } from "@/lib/utils";
+import { useGridEditorStore } from "@/stores/grid-editor";
 import { useSquareSelectionStore } from "@/stores/square-selection";
 import { ChordSearch } from "./chord-search";
 
@@ -47,6 +49,9 @@ export function GridSquare({
   const isSelected = useSquareSelectionStore((s) => s.selected.has(index));
   const handleSquareClick =
     useSquareSelectionStore.getState().handleSquareClick;
+
+  const transpose = useGridEditorStore((s) => s.transpose);
+  const displayChord = chord ? transposeChord(chord, transpose) : null;
 
   useEffect(() => {
     if (autoFocus) {
@@ -124,7 +129,7 @@ export function GridSquare({
             ? "border-primary bg-primary/20 ring-2 ring-primary"
             : isPlaying
               ? "bg-primary text-primary-foreground shadow-[var(--shadow-brutal)] border-border"
-              : chord
+              : displayChord
                 ? "bg-card hover:-translate-y-0.5 hover:shadow-[var(--shadow-brutal)] border-border"
                 : "bg-background text-muted-foreground hover:-translate-y-0.5 hover:shadow-[var(--shadow-brutal)] border-border"
         }`}
@@ -132,7 +137,7 @@ export function GridSquare({
           groupColor && !isSelected ? { borderColor: groupColor } : undefined
         }
       >
-        {chord ?? t("accomp.emptySquare")}
+        {displayChord ?? t("accomp.emptySquare")}
       </button>
       <div
         onPointerDown={handleResizePointerDown}

--- a/packages/web/src/lib/utils.test.ts
+++ b/packages/web/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { cn } from "./utils";
+import { cn, transposeChord } from "./utils";
 
 describe("cn", () => {
   it("merges class names", () => {
@@ -17,5 +17,37 @@ describe("cn", () => {
 
   it("handles empty and undefined inputs", () => {
     expect(cn("", undefined, null, "foo")).toBe("foo");
+  });
+});
+
+describe("transposeChord", () => {
+  it("should transpose chords up by semitones", () => {
+    expect(transposeChord("C", 2)).toBe("D");
+    expect(transposeChord("Cm", 2)).toBe("Dm");
+    expect(transposeChord("F7", 7)).toBe("C7");
+  });
+
+  it("should transpose chords down by semitones", () => {
+    expect(transposeChord("C", -2)).toBe("Bb");
+    expect(transposeChord("Cm", -2)).toBe("Bbm");
+    // D down 1 semitone can be either Db or C# (enharmonic equivalents)
+    const result = transposeChord("D", -1);
+    expect(result === "Db" || result === "C#").toBe(true);
+  });
+
+  it("should handle edge cases", () => {
+    expect(transposeChord(null, 5)).toBe(null);
+    expect(transposeChord("C", 0)).toBe("C");
+    expect(transposeChord("", 5)).toBe("");
+  });
+
+  it("should handle invalid semitone values", () => {
+    expect(transposeChord("C", 15)).toBe("C");
+    expect(transposeChord("C", -15)).toBe("C");
+  });
+
+  it("should handle complex chords", () => {
+    expect(transposeChord("Dm7b5", 5)).toBe("Gm7b5");
+    expect(transposeChord("Cmaj7", 4)).toBe("Emaj7");
   });
 });

--- a/packages/web/src/lib/utils.ts
+++ b/packages/web/src/lib/utils.ts
@@ -1,6 +1,58 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
+import { Chord } from "tonal";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
+}
+
+/**
+ * Transpose a chord by the specified number of semitones.
+ * @param chord - Chord symbol (e.g., "Cm", "F7", "Dm7b5")
+ * @param semitones - Number of semitones to transpose (can be negative)
+ * @returns Transposed chord symbol, or null if invalid
+ */
+export function transposeChord(
+  chord: string | null,
+  semitones: number,
+): string | null {
+  if (!chord || semitones === 0) return chord;
+
+  try {
+    // Convert semitones to interval string for Tonal
+    const intervalMap: Record<string, string> = {
+      "-12": "-8P",
+      "-11": "-7M",
+      "-10": "-7m",
+      "-9": "-6M",
+      "-8": "-6m",
+      "-7": "-5P",
+      "-6": "-5d",
+      "-5": "-4P",
+      "-4": "-3M",
+      "-3": "-3m",
+      "-2": "-2M",
+      "-1": "-2m",
+      "1": "2m",
+      "2": "2M",
+      "3": "3m",
+      "4": "3M",
+      "5": "4P",
+      "6": "5d",
+      "7": "5P",
+      "8": "6m",
+      "9": "6M",
+      "10": "7m",
+      "11": "7M",
+      "12": "8P",
+    };
+
+    const interval = intervalMap[semitones.toString()];
+    if (!interval) return chord; // Invalid semitone value
+
+    const result = Chord.transpose(chord, interval);
+    return result || null;
+  } catch {
+    return null;
+  }
 }

--- a/packages/web/src/localizations/en.ts
+++ b/packages/web/src/localizations/en.ts
@@ -138,6 +138,8 @@ export default {
     publicGrids: "Public Grids",
     publicGridsDescription: "Browse and play grids shared by other users.",
     noPublicGrids: "No public grids yet.",
+    transpose: "Transpose",
+    semitones: "semitones",
   },
   tour: {
     helpButton: "Tour",

--- a/packages/web/src/localizations/es.ts
+++ b/packages/web/src/localizations/es.ts
@@ -139,6 +139,8 @@ export default {
     publicGridsDescription:
       "Navega y toca tablas compartidas por otros usuarios.",
     noPublicGrids: "No hay tablas públicas aún.",
+    transpose: "Transponer",
+    semitones: "semitonos",
   },
   tour: {
     helpButton: "Tour",

--- a/packages/web/src/localizations/fr.ts
+++ b/packages/web/src/localizations/fr.ts
@@ -140,6 +140,8 @@ export default {
     publicGridsDescription:
       "Parcourez et jouez les grilles partagées par d'autres utilisateurs.",
     noPublicGrids: "Aucune grille publique pour le moment.",
+    transpose: "Transposer",
+    semitones: "demi-tons",
   },
   tour: {
     helpButton: "Visite",

--- a/packages/web/src/localizations/zh.ts
+++ b/packages/web/src/localizations/zh.ts
@@ -135,6 +135,8 @@ export default {
     publicGrids: "公开表格",
     publicGridsDescription: "浏览和播放其他用户分享的表格。",
     noPublicGrids: "暂无公开表格。",
+    transpose: "移调",
+    semitones: "半音",
   },
   tour: {
     helpButton: "导览",

--- a/packages/web/src/routes/accomp.$gridId.tsx
+++ b/packages/web/src/routes/accomp.$gridId.tsx
@@ -39,6 +39,8 @@ function GridEditor() {
   const updateKey = useGridEditorStore((s) => s.updateKey);
   const updateVisibility = useGridEditorStore((s) => s.updateVisibility);
   const groupSquares = useGridEditorStore((s) => s.groupSquares);
+  const transpose = useGridEditorStore((s) => s.transpose);
+  const updateTranspose = useGridEditorStore((s) => s.updateTranspose);
 
   const playback = useGridPlayback(data, tempo, loopCount, timeSignature);
 
@@ -191,6 +193,22 @@ function GridEditor() {
               placeholder={t("accomp.keyPlaceholder")}
               className="w-20 border-b-2 border-border bg-transparent px-1 py-0.5 text-sm focus:outline-none"
             />
+          </label>
+          <label className="flex items-center gap-1.5 text-sm">
+            <span className="font-bold text-muted-foreground">
+              {t("accomp.transpose")}
+            </span>
+            <input
+              type="number"
+              value={transpose}
+              onChange={(e) => updateTranspose(Number(e.target.value))}
+              min="-12"
+              max="12"
+              className="w-16 border-b-2 border-border bg-transparent px-1 py-0.5 text-sm focus:outline-none"
+            />
+            <span className="text-xs text-muted-foreground">
+              {t("accomp.semitones")}
+            </span>
           </label>
         </div>
 

--- a/packages/web/src/stores/grid-editor.ts
+++ b/packages/web/src/stores/grid-editor.ts
@@ -128,6 +128,7 @@ interface GridEditorState {
   timeSignature: TimeSignature;
   data: GridData;
   isDirty: boolean;
+  transpose: number; // Number of semitones to transpose (for display only)
 }
 
 interface GridEditorActions {
@@ -158,6 +159,7 @@ interface GridEditorActions {
   mergeWithPreviousGroup: (groupIndex: number) => void;
   deleteGroup: (groupIndex: number) => void;
   groupSquares: (startIndex: number, endIndex: number) => void;
+  updateTranspose: (semitones: number) => void;
 }
 
 export type GridEditorStore = GridEditorState & GridEditorActions;
@@ -173,6 +175,7 @@ const initialState: GridEditorState = {
   timeSignature: DEFAULT_TIME_SIGNATURE,
   data: DEFAULT_DATA,
   isDirty: false,
+  transpose: 0,
 };
 
 export const useGridEditorStore = create<GridEditorStore>((set, get) => ({
@@ -558,4 +561,7 @@ export const useGridEditorStore = create<GridEditorStore>((set, get) => ({
         isDirty: true,
       };
     }),
+
+  updateTranspose: (semitones) =>
+    set({ transpose: Math.max(-12, Math.min(12, semitones)) }),
 }));


### PR DESCRIPTION
Implements transpose functionality for chord grids as requested in issue #30.

**Features:**
- Transpose input field with -12 to +12 semitones range
- Real-time chord transposition using Tonal library
- Frontend-only implementation (doesn't modify saved data)
- Full internationalization support
- Comprehensive test coverage

**Technical Implementation:**
- New `transposeChord()` utility function
- Updated GridEditorStore with transpose state
- Modified GridSquare component for display logic
- Added i18n keys to all language files

Closes #30

🤖 Generated with [Claude Code](https://claude.ai/code)