### PR TITLE
feat: add loop counter indicator during playback

### DIFF
--- a/packages/web/src/components/accomp/playback-controls.tsx
+++ b/packages/web/src/components/accomp/playback-controls.tsx
@@ -221,6 +221,7 @@ export function SettingsControls({
 interface PlaybackProps {
   isPlaying: boolean;
   isSaving: boolean;
+  currentLoop: number;
   onPlay: () => void;
   onStop: () => void;
   onSave: () => void;
@@ -229,6 +230,7 @@ interface PlaybackProps {
 export function PlaybackControls({
   isPlaying,
   isSaving,
+  currentLoop,
   onPlay,
   onStop,
   onSave,
@@ -283,6 +285,14 @@ export function PlaybackControls({
           disabled={isPlaying}
           className="w-16 border-3 border-border bg-background px-2 py-1 text-center font-mono text-sm font-bold focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
         />
+        {isPlaying && (
+          <span className="border-2 border-border bg-accent px-2 py-1 font-mono text-xs font-bold text-accent-foreground">
+            {t("accomp.currentLoop", {
+              current: currentLoop + 1,
+              total: loopCount,
+            })}
+          </span>
+        )}
       </div>
 
       <button

--- a/packages/web/src/hooks/use-grid-playback.ts
+++ b/packages/web/src/hooks/use-grid-playback.ts
@@ -89,6 +89,7 @@ export function useGridPlayback(
 ) {
   const [isPlaying, setIsPlaying] = useState(false);
   const [currentIndex, setCurrentIndex] = useState<number | null>(null);
+  const [currentLoop, setCurrentLoop] = useState(0);
   const [metronome, setMetronome] = useState(false);
   const [style, setStyle] = useState<StyleId | null>(null);
   const [swing, setSwing] = useState(0);
@@ -130,6 +131,7 @@ export function useGridPlayback(
     stopBass();
     setIsPlaying(false);
     setCurrentIndex(null);
+    setCurrentLoop(0);
   }, [clearScheduled, stopAll]);
 
   const toggleMetronome = useCallback(() => setMetronome((v) => !v), []);
@@ -141,6 +143,7 @@ export function useGridPlayback(
     await ensureReady();
     isPlayingRef.current = true;
     setIsPlaying(true);
+    setCurrentLoop(0);
 
     const currentStyle: Style | null = styleRef.current
       ? STYLES[styleRef.current]
@@ -192,6 +195,7 @@ export function useGridPlayback(
 
         if (squareIdx >= allSquares.length) {
           currentLoop++;
+          setCurrentLoop(currentLoop);
           if (currentLoop >= loopCount) {
             stop();
             return;
@@ -278,6 +282,7 @@ export function useGridPlayback(
   return {
     isPlaying,
     currentIndex,
+    currentLoop,
     metronome,
     toggleMetronome,
     chordsEnabled,

--- a/packages/web/src/localizations/en.ts
+++ b/packages/web/src/localizations/en.ts
@@ -81,6 +81,7 @@ export default {
     tempo: "Tempo",
     bpm: "BPM",
     loopCount: "Loops",
+    currentLoop: "Loop {{current}}/{{total}}",
     metronome: "Metronome",
     chords: "Chords",
     bass: "Bass",

--- a/packages/web/src/localizations/es.ts
+++ b/packages/web/src/localizations/es.ts
@@ -81,6 +81,7 @@ export default {
     tempo: "Tempo",
     bpm: "BPM",
     loopCount: "Bucles",
+    currentLoop: "Bucle {{current}}/{{total}}",
     metronome: "Metrónomo",
     chords: "Acordes",
     bass: "Bajo",

--- a/packages/web/src/localizations/fr.ts
+++ b/packages/web/src/localizations/fr.ts
@@ -82,6 +82,7 @@ export default {
     tempo: "Tempo",
     bpm: "BPM",
     loopCount: "Boucles",
+    currentLoop: "Boucle {{current}}/{{total}}",
     metronome: "Métronome",
     chords: "Accords",
     bass: "Basse",

--- a/packages/web/src/localizations/zh.ts
+++ b/packages/web/src/localizations/zh.ts
@@ -79,6 +79,7 @@ export default {
     tempo: "速度",
     bpm: "BPM",
     loopCount: "循环次数",
+    currentLoop: "循环 {{current}}/{{total}}",
     metronome: "节拍器",
     chords: "和弦",
     bass: "贝斯",

--- a/packages/web/src/routes/accomp.$gridId.tsx
+++ b/packages/web/src/routes/accomp.$gridId.tsx
@@ -198,6 +198,7 @@ function GridEditor() {
           <PlaybackControls
             isPlaying={playback.isPlaying}
             isSaving={isSaving}
+            currentLoop={playback.currentLoop}
             onPlay={playback.play}
             onStop={playback.stop}
             onSave={save}


### PR DESCRIPTION
Closes #31

Adds an indicator showing which loop is currently playing during playback.

## Changes
- Add currentLoop state to useGridPlayback hook
- Display current loop number when playback is active
- Show loop indicator as 'Loop X/Y' format during playback
- Add translations for currentLoop in all locales (en, fr, es, zh)

## Test Plan
1. Navigate to the accompaniment section
2. Create or open a chord grid
3. Set loop count to more than 1
4. Start playback
5. Verify loop indicator appears showing "Loop 1/[total]"
6. Wait for loop to complete and verify counter increments
7. Stop playback and verify indicator disappears

Generated with [Claude Code](https://claude.ai/code)